### PR TITLE
Import 2022-2024 seasons from hockeypool CSVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Year files store facts only. Points and standings are computed from `rules.json`
   "year": 2026,
   "status": "in-progress",        // or "complete"
   "champion": "VGK",              // final winner, null while in progress
-  "matchupsReconstructed": false, // true for 2018-2022 (opponents recovered via research)
+  "matchupsReconstructed": false, // true for 2018-2021 (opponents recovered via research)
   "source": "...",
   "rounds": [
     {
@@ -110,12 +110,17 @@ Eleventy's `pathPrefix` and use the `url` filter.
 
 - 2026: the current season's picks
 - 2025: the `Projects/picks` markdown pool
-- 2018-2022: the original `tollmanz/bracket` repo. Those files recorded only the winning
+- 2022-2024: John Hawkins's hockeypool CSV export, which records both teams, every pick,
+  and the actual result per series. Matchups are authoritative (not reconstructed). This
+  replaced the earlier partial 2022 reconstruction, which covered only rounds 1 and 2.
+- 2018-2021: the original `tollmanz/bracket` repo. Those files recorded only the winning
   team and game count per round, so series opponents were reconstructed from historical
   playoff results and verified against the recorded winners and the known Stanley Cup
-  champion. 2022 source data covers only rounds 1 and 2.
+  champion.
 
 `@TTollman` (Tyler Tollman) appears only in 2019-2020, and `@thoronas` is Flynn O'Connor
-under an old handle (merged into `flynn`). The remaining early-years handles `@nacin`,
-`@brothernacin`, `@fathernacin`, `@cklosowski` are stored under their handle; edit
-`data/people.json` to give them a display name.
+under an old handle (merged into `flynn`). `@NerdyByProxy` joined in 2023-2024; `@ThomasKnoll`
+registered for 2024 but submitted no picks, so he holds no series and does not appear.
+The remaining early-years handles `@nacin`, `@brothernacin`, `@fathernacin`, `@cklosowski`
+and `@NerdyByProxy` are stored under their handle; edit `data/people.json` to give them a
+display name.

--- a/data/2023.json
+++ b/data/2023.json
@@ -1,7 +1,7 @@
 {
-  "year": 2022,
+  "year": 2023,
   "status": "complete",
-  "champion": "COL",
+  "champion": "VGK",
   "matchupsReconstructed": false,
   "source": "hockeypool CSV export (John Hawkins)",
   "rounds": [
@@ -11,44 +11,145 @@
       "series": [
         {
           "teams": [
-            "FLA",
-            "WSH"
+            "BOS",
+            "FLA"
           ],
           "result": {
             "status": "final",
             "winner": "FLA",
+            "games": 7
+          },
+          "picks": [
+            {
+              "person": "aaron",
+              "team": "BOS",
+              "games": 4
+            },
+            {
+              "person": "cklosowski",
+              "team": "BOS",
+              "games": 5
+            },
+            {
+              "person": "jonathan",
+              "team": "BOS",
+              "games": 5
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "BOS",
+              "games": 4
+            },
+            {
+              "person": "flynn",
+              "team": "BOS",
+              "games": 5
+            },
+            {
+              "person": "zack",
+              "team": "BOS",
+              "games": 5
+            },
+            {
+              "person": "john",
+              "team": "BOS",
+              "games": 4
+            }
+          ]
+        },
+        {
+          "teams": [
+            "CAR",
+            "NYI"
+          ],
+          "result": {
+            "status": "final",
+            "winner": "CAR",
             "games": 6
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "FLA",
-              "games": 5
+              "team": "NYI",
+              "games": 7
             },
             {
               "person": "cklosowski",
-              "team": "FLA",
-              "games": 5
+              "team": "CAR",
+              "games": 6
             },
             {
               "person": "jonathan",
-              "team": "FLA",
+              "team": "CAR",
+              "games": 4
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "CAR",
               "games": 6
             },
             {
               "person": "flynn",
-              "team": "FLA",
-              "games": 5
+              "team": "NYI",
+              "games": 7
             },
             {
               "person": "zack",
-              "team": "FLA",
+              "team": "CAR",
               "games": 4
             },
             {
               "person": "john",
-              "team": "FLA",
+              "team": "CAR",
+              "games": 4
+            }
+          ]
+        },
+        {
+          "teams": [
+            "NJD",
+            "NYR"
+          ],
+          "result": {
+            "status": "final",
+            "winner": "NJD",
+            "games": 7
+          },
+          "picks": [
+            {
+              "person": "aaron",
+              "team": "NYR",
               "games": 6
+            },
+            {
+              "person": "cklosowski",
+              "team": "NYR",
+              "games": 6
+            },
+            {
+              "person": "jonathan",
+              "team": "NJD",
+              "games": 7
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "NYR",
+              "games": 5
+            },
+            {
+              "person": "flynn",
+              "team": "NYR",
+              "games": 6
+            },
+            {
+              "person": "zack",
+              "team": "NJD",
+              "games": 6
+            },
+            {
+              "person": "john",
+              "team": "NJD",
+              "games": 7
             }
           ]
         },
@@ -59,24 +160,29 @@
           ],
           "result": {
             "status": "final",
-            "winner": "TBL",
-            "games": 7
+            "winner": "TOR",
+            "games": 6
           },
           "picks": [
             {
               "person": "aaron",
+              "team": "TOR",
+              "games": 5
+            },
+            {
+              "person": "cklosowski",
               "team": "TBL",
               "games": 4
             },
             {
-              "person": "cklosowski",
-              "team": "TBL",
-              "games": 5
+              "person": "jonathan",
+              "team": "TOR",
+              "games": 6
             },
             {
-              "person": "jonathan",
-              "team": "TBL",
-              "games": 6
+              "person": "nerdybyproxy",
+              "team": "TOR",
+              "games": 7
             },
             {
               "person": "flynn",
@@ -90,223 +196,152 @@
             },
             {
               "person": "john",
-              "team": "TOR",
-              "games": 7
+              "team": "TBL",
+              "games": 6
             }
           ]
         },
         {
           "teams": [
-            "CAR",
-            "BOS"
+            "VGK",
+            "WPG"
           ],
           "result": {
             "status": "final",
-            "winner": "CAR",
-            "games": 7
+            "winner": "VGK",
+            "games": 5
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "CAR",
-              "games": 6
+              "team": "VGK",
+              "games": 5
             },
             {
               "person": "cklosowski",
-              "team": "CAR",
+              "team": "WPG",
               "games": 5
             },
             {
               "person": "jonathan",
-              "team": "CAR",
+              "team": "VGK",
+              "games": 6
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "VGK",
               "games": 6
             },
             {
               "person": "flynn",
-              "team": "CAR",
+              "team": "WPG",
               "games": 7
             },
             {
               "person": "zack",
-              "team": "CAR",
-              "games": 7
+              "team": "VGK",
+              "games": 5
             },
             {
               "person": "john",
-              "team": "CAR",
-              "games": 5
-            }
-          ]
-        },
-        {
-          "teams": [
-            "NYR",
-            "PIT"
-          ],
-          "result": {
-            "status": "final",
-            "winner": "NYR",
-            "games": 7
-          },
-          "picks": [
-            {
-              "person": "aaron",
-              "team": "PIT",
-              "games": 7
-            },
-            {
-              "person": "cklosowski",
-              "team": "NYR",
-              "games": 6
-            },
-            {
-              "person": "jonathan",
-              "team": "NYR",
-              "games": 5
-            },
-            {
-              "person": "flynn",
-              "team": "PIT",
-              "games": 6
-            },
-            {
-              "person": "zack",
-              "team": "PIT",
-              "games": 6
-            },
-            {
-              "person": "john",
-              "team": "NYR",
-              "games": 5
+              "team": "VGK",
+              "games": 4
             }
           ]
         },
         {
           "teams": [
             "COL",
-            "NSH"
+            "SEA"
           ],
           "result": {
             "status": "final",
-            "winner": "COL",
-            "games": 4
-          },
-          "picks": [
-            {
-              "person": "aaron",
-              "team": "COL",
-              "games": 5
-            },
-            {
-              "person": "cklosowski",
-              "team": "COL",
-              "games": 6
-            },
-            {
-              "person": "jonathan",
-              "team": "COL",
-              "games": 5
-            },
-            {
-              "person": "flynn",
-              "team": "COL",
-              "games": 4
-            },
-            {
-              "person": "zack",
-              "team": "COL",
-              "games": 5
-            },
-            {
-              "person": "john",
-              "team": "COL",
-              "games": 6
-            }
-          ]
-        },
-        {
-          "teams": [
-            "MIN",
-            "STL"
-          ],
-          "result": {
-            "status": "final",
-            "winner": "STL",
-            "games": 6
-          },
-          "picks": [
-            {
-              "person": "aaron",
-              "team": "MIN",
-              "games": 6
-            },
-            {
-              "person": "cklosowski",
-              "team": "STL",
-              "games": 6
-            },
-            {
-              "person": "jonathan",
-              "team": "STL",
-              "games": 5
-            },
-            {
-              "person": "flynn",
-              "team": "MIN",
-              "games": 5
-            },
-            {
-              "person": "zack",
-              "team": "STL",
-              "games": 6
-            },
-            {
-              "person": "john",
-              "team": "MIN",
-              "games": 6
-            }
-          ]
-        },
-        {
-          "teams": [
-            "CGY",
-            "DAL"
-          ],
-          "result": {
-            "status": "final",
-            "winner": "CGY",
+            "winner": "SEA",
             "games": 7
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "CGY",
+              "team": "COL",
               "games": 6
             },
             {
               "person": "cklosowski",
-              "team": "CGY",
-              "games": 4
+              "team": "COL",
+              "games": 5
             },
             {
               "person": "jonathan",
-              "team": "CGY",
-              "games": 6
+              "team": "COL",
+              "games": 5
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "COL",
+              "games": 5
             },
             {
               "person": "flynn",
-              "team": "CGY",
+              "team": "COL",
               "games": 5
             },
             {
               "person": "zack",
-              "team": "CGY",
+              "team": "COL",
               "games": 6
             },
             {
               "person": "john",
-              "team": "CGY",
+              "team": "COL",
+              "games": 4
+            }
+          ]
+        },
+        {
+          "teams": [
+            "DAL",
+            "MIN"
+          ],
+          "result": {
+            "status": "final",
+            "winner": "DAL",
+            "games": 6
+          },
+          "picks": [
+            {
+              "person": "aaron",
+              "team": "DAL",
               "games": 7
+            },
+            {
+              "person": "cklosowski",
+              "team": "MIN",
+              "games": 5
+            },
+            {
+              "person": "jonathan",
+              "team": "DAL",
+              "games": 7
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "DAL",
+              "games": 7
+            },
+            {
+              "person": "flynn",
+              "team": "DAL",
+              "games": 7
+            },
+            {
+              "person": "zack",
+              "team": "MIN",
+              "games": 7
+            },
+            {
+              "person": "john",
+              "team": "DAL",
+              "games": 6
             }
           ]
         },
@@ -318,23 +353,28 @@
           "result": {
             "status": "final",
             "winner": "EDM",
-            "games": 7
+            "games": 6
           },
           "picks": [
             {
               "person": "aaron",
               "team": "EDM",
-              "games": 4
+              "games": 5
             },
             {
               "person": "cklosowski",
               "team": "EDM",
-              "games": 5
+              "games": 6
             },
             {
               "person": "jonathan",
               "team": "EDM",
-              "games": 4
+              "games": 6
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "EDM",
+              "games": 6
             },
             {
               "person": "flynn",
@@ -343,13 +383,13 @@
             },
             {
               "person": "zack",
-              "team": "LAK",
-              "games": 7
+              "team": "EDM",
+              "games": 6
             },
             {
               "person": "john",
               "team": "EDM",
-              "games": 5
+              "games": 7
             }
           ]
         }
@@ -362,33 +402,38 @@
         {
           "teams": [
             "FLA",
-            "TBL"
+            "TOR"
           ],
           "result": {
             "status": "final",
-            "winner": "TBL",
-            "games": 4
+            "winner": "FLA",
+            "games": 5
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "TBL",
+              "team": "TOR",
               "games": 6
             },
             {
               "person": "cklosowski",
-              "team": "FLA",
-              "games": 6
+              "team": "TOR",
+              "games": 5
             },
             {
               "person": "jonathan",
-              "team": "FLA",
+              "team": "TOR",
+              "games": 6
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "TOR",
               "games": 7
             },
             {
               "person": "flynn",
-              "team": "TBL",
-              "games": 7
+              "team": "TOR",
+              "games": 5
             },
             {
               "person": "zack",
@@ -398,136 +443,151 @@
             {
               "person": "john",
               "team": "FLA",
-              "games": 6
+              "games": 5
             }
           ]
         },
         {
           "teams": [
             "CAR",
-            "NYR"
+            "NJD"
           ],
           "result": {
             "status": "final",
-            "winner": "NYR",
-            "games": 7
-          },
-          "picks": [
-            {
-              "person": "aaron",
-              "team": "CAR",
-              "games": 6
-            },
-            {
-              "person": "cklosowski",
-              "team": "CAR",
-              "games": 6
-            },
-            {
-              "person": "jonathan",
-              "team": "CAR",
-              "games": 5
-            },
-            {
-              "person": "flynn",
-              "team": "CAR",
-              "games": 6
-            },
-            {
-              "person": "zack",
-              "team": "CAR",
-              "games": 6
-            },
-            {
-              "person": "john",
-              "team": "CAR",
-              "games": 7
-            }
-          ]
-        },
-        {
-          "teams": [
-            "COL",
-            "STL"
-          ],
-          "result": {
-            "status": "final",
-            "winner": "COL",
-            "games": 6
-          },
-          "picks": [
-            {
-              "person": "aaron",
-              "team": "COL",
-              "games": 6
-            },
-            {
-              "person": "cklosowski",
-              "team": "COL",
-              "games": 5
-            },
-            {
-              "person": "jonathan",
-              "team": "COL",
-              "games": 6
-            },
-            {
-              "person": "flynn",
-              "team": "COL",
-              "games": 6
-            },
-            {
-              "person": "zack",
-              "team": "COL",
-              "games": 6
-            },
-            {
-              "person": "john",
-              "team": "COL",
-              "games": 6
-            }
-          ]
-        },
-        {
-          "teams": [
-            "CGY",
-            "EDM"
-          ],
-          "result": {
-            "status": "final",
-            "winner": "EDM",
+            "winner": "CAR",
             "games": 5
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "CGY",
+              "team": "NJD",
+              "games": 6
+            },
+            {
+              "person": "cklosowski",
+              "team": "CAR",
+              "games": 6
+            },
+            {
+              "person": "jonathan",
+              "team": "CAR",
+              "games": 7
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "CAR",
+              "games": 6
+            },
+            {
+              "person": "flynn",
+              "team": "NJD",
+              "games": 6
+            },
+            {
+              "person": "zack",
+              "team": "CAR",
+              "games": 6
+            },
+            {
+              "person": "john",
+              "team": "NJD",
+              "games": 6
+            }
+          ]
+        },
+        {
+          "teams": [
+            "SEA",
+            "DAL"
+          ],
+          "result": {
+            "status": "final",
+            "winner": "DAL",
+            "games": 7
+          },
+          "picks": [
+            {
+              "person": "aaron",
+              "team": "SEA",
+              "games": 6
+            },
+            {
+              "person": "cklosowski",
+              "team": "SEA",
+              "games": 6
+            },
+            {
+              "person": "jonathan",
+              "team": "SEA",
+              "games": 7
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "DAL",
+              "games": 5
+            },
+            {
+              "person": "flynn",
+              "team": "DAL",
+              "games": 7
+            },
+            {
+              "person": "zack",
+              "team": "SEA",
+              "games": 6
+            },
+            {
+              "person": "john",
+              "team": "DAL",
+              "games": 6
+            }
+          ]
+        },
+        {
+          "teams": [
+            "VGK",
+            "EDM"
+          ],
+          "result": {
+            "status": "final",
+            "winner": "VGK",
+            "games": 6
+          },
+          "picks": [
+            {
+              "person": "aaron",
+              "team": "EDM",
               "games": 7
             },
             {
               "person": "cklosowski",
               "team": "EDM",
-              "games": 7
+              "games": 5
             },
             {
               "person": "jonathan",
               "team": "EDM",
-              "games": 7
+              "games": 6
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "EDM",
+              "games": 6
             },
             {
               "person": "flynn",
-              "team": "CGY",
+              "team": "EDM",
               "games": 6
             },
             {
               "person": "zack",
               "team": "EDM",
-              "games": 7
+              "games": 5
             },
             {
               "person": "john",
-              "team": "CGY",
-              "games": 6
+              "team": "VGK",
+              "games": 7
             }
           ]
         }
@@ -539,87 +599,87 @@
       "series": [
         {
           "teams": [
-            "NYR",
-            "TBL"
+            "CAR",
+            "FLA"
           ],
           "result": {
             "status": "final",
-            "winner": "TBL",
-            "games": 6
+            "winner": "FLA",
+            "games": 4
           },
           "picks": [
             {
-              "person": "aaron",
-              "team": "TBL",
-              "games": 6
-            },
-            {
               "person": "cklosowski",
-              "team": "TBL",
+              "team": "CAR",
               "games": 5
             },
             {
               "person": "jonathan",
-              "team": "TBL",
+              "team": "CAR",
               "games": 6
             },
             {
+              "person": "nerdybyproxy",
+              "team": "FLA",
+              "games": 7
+            },
+            {
               "person": "flynn",
-              "team": "TBL",
-              "games": 5
+              "team": "FLA",
+              "games": 6
             },
             {
               "person": "zack",
-              "team": "TBL",
+              "team": "FLA",
               "games": 6
             },
             {
               "person": "john",
-              "team": "TBL",
-              "games": 6
+              "team": "CAR",
+              "games": 7
             }
           ]
         },
         {
           "teams": [
-            "COL",
-            "EDM"
+            "VGK",
+            "DAL"
           ],
           "result": {
             "status": "final",
-            "winner": "COL",
-            "games": 4
+            "winner": "VGK",
+            "games": 6
           },
           "picks": [
             {
-              "person": "aaron",
-              "team": "EDM",
-              "games": 7
-            },
-            {
               "person": "cklosowski",
-              "team": "EDM",
+              "team": "VGK",
               "games": 6
             },
             {
               "person": "jonathan",
-              "team": "EDM",
-              "games": 7
+              "team": "VGK",
+              "games": 6
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "VGK",
+              "games": 6
             },
             {
               "person": "flynn",
-              "team": "COL",
-              "games": 7
+              "team": "DAL",
+              "games": 6
             },
             {
               "person": "zack",
-              "team": "COL",
+              "team": "VGK",
               "games": 7
             },
             {
               "person": "john",
-              "team": "EDM",
-              "games": 7
+              "team": "VGK",
+              "games": 6
             }
           ]
         }
@@ -631,44 +691,39 @@
       "series": [
         {
           "teams": [
-            "COL",
-            "TBL"
+            "VGK",
+            "FLA"
           ],
           "result": {
             "status": "final",
-            "winner": "COL",
-            "games": 6
+            "winner": "VGK",
+            "games": 5
           },
           "picks": [
             {
-              "person": "aaron",
-              "team": "COL",
-              "games": 6
-            },
-            {
               "person": "cklosowski",
-              "team": "COL",
+              "team": "VGK",
               "games": 5
             },
             {
               "person": "jonathan",
-              "team": "TBL",
+              "team": "VGK",
               "games": 7
             },
             {
-              "person": "flynn",
-              "team": "COL",
-              "games": 6
+              "person": "nerdybyproxy",
+              "team": "VGK",
+              "games": 5
             },
             {
               "person": "zack",
-              "team": "COL",
+              "team": "FLA",
               "games": 6
             },
             {
               "person": "john",
-              "team": "COL",
-              "games": 7
+              "team": "VGK",
+              "games": 6
             }
           ]
         }

--- a/data/2024.json
+++ b/data/2024.json
@@ -1,7 +1,7 @@
 {
-  "year": 2022,
+  "year": 2024,
   "status": "complete",
-  "champion": "COL",
+  "champion": "FLA",
   "matchupsReconstructed": false,
   "source": "hockeypool CSV export (John Hawkins)",
   "rounds": [
@@ -12,301 +12,336 @@
         {
           "teams": [
             "FLA",
-            "WSH"
-          ],
-          "result": {
-            "status": "final",
-            "winner": "FLA",
-            "games": 6
-          },
-          "picks": [
-            {
-              "person": "aaron",
-              "team": "FLA",
-              "games": 5
-            },
-            {
-              "person": "cklosowski",
-              "team": "FLA",
-              "games": 5
-            },
-            {
-              "person": "jonathan",
-              "team": "FLA",
-              "games": 6
-            },
-            {
-              "person": "flynn",
-              "team": "FLA",
-              "games": 5
-            },
-            {
-              "person": "zack",
-              "team": "FLA",
-              "games": 4
-            },
-            {
-              "person": "john",
-              "team": "FLA",
-              "games": 6
-            }
-          ]
-        },
-        {
-          "teams": [
-            "TOR",
             "TBL"
           ],
           "result": {
             "status": "final",
-            "winner": "TBL",
-            "games": 7
+            "winner": "FLA",
+            "games": 5
           },
           "picks": [
             {
               "person": "aaron",
               "team": "TBL",
-              "games": 4
+              "games": 6
             },
             {
               "person": "cklosowski",
               "team": "TBL",
-              "games": 5
+              "games": 4
             },
             {
               "person": "jonathan",
               "team": "TBL",
+              "games": 5
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "FLA",
               "games": 6
             },
             {
               "person": "flynn",
-              "team": "TOR",
+              "team": "FLA",
               "games": 6
             },
             {
               "person": "zack",
-              "team": "TOR",
-              "games": 7
+              "team": "FLA",
+              "games": 5
             },
             {
               "person": "john",
-              "team": "TOR",
-              "games": 7
+              "team": "FLA",
+              "games": 5
             }
           ]
         },
         {
           "teams": [
-            "CAR",
-            "BOS"
+            "BOS",
+            "TOR"
           ],
           "result": {
             "status": "final",
-            "winner": "CAR",
+            "winner": "BOS",
             "games": 7
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "CAR",
-              "games": 6
-            },
-            {
-              "person": "cklosowski",
-              "team": "CAR",
+              "team": "BOS",
               "games": 5
             },
             {
+              "person": "cklosowski",
+              "team": "TOR",
+              "games": 4
+            },
+            {
               "person": "jonathan",
-              "team": "CAR",
+              "team": "BOS",
+              "games": 4
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "TOR",
               "games": 6
             },
             {
               "person": "flynn",
-              "team": "CAR",
+              "team": "BOS",
               "games": 7
             },
             {
               "person": "zack",
-              "team": "CAR",
+              "team": "BOS",
               "games": 7
             },
             {
               "person": "john",
-              "team": "CAR",
-              "games": 5
+              "team": "BOS",
+              "games": 6
             }
           ]
         },
         {
           "teams": [
             "NYR",
-            "PIT"
+            "WSH"
           ],
           "result": {
             "status": "final",
             "winner": "NYR",
-            "games": 7
-          },
-          "picks": [
-            {
-              "person": "aaron",
-              "team": "PIT",
-              "games": 7
-            },
-            {
-              "person": "cklosowski",
-              "team": "NYR",
-              "games": 6
-            },
-            {
-              "person": "jonathan",
-              "team": "NYR",
-              "games": 5
-            },
-            {
-              "person": "flynn",
-              "team": "PIT",
-              "games": 6
-            },
-            {
-              "person": "zack",
-              "team": "PIT",
-              "games": 6
-            },
-            {
-              "person": "john",
-              "team": "NYR",
-              "games": 5
-            }
-          ]
-        },
-        {
-          "teams": [
-            "COL",
-            "NSH"
-          ],
-          "result": {
-            "status": "final",
-            "winner": "COL",
             "games": 4
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "COL",
-              "games": 5
+              "team": "NYR",
+              "games": 4
             },
             {
               "person": "cklosowski",
-              "team": "COL",
-              "games": 6
+              "team": "WSH",
+              "games": 5
             },
             {
               "person": "jonathan",
-              "team": "COL",
+              "team": "NYR",
+              "games": 4
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "NYR",
               "games": 5
             },
             {
               "person": "flynn",
-              "team": "COL",
+              "team": "NYR",
               "games": 4
             },
             {
               "person": "zack",
-              "team": "COL",
-              "games": 5
+              "team": "NYR",
+              "games": 6
             },
             {
               "person": "john",
-              "team": "COL",
-              "games": 6
+              "team": "NYR",
+              "games": 4
             }
           ]
         },
         {
           "teams": [
-            "MIN",
-            "STL"
+            "CAR",
+            "NYI"
           ],
           "result": {
             "status": "final",
-            "winner": "STL",
-            "games": 6
+            "winner": "CAR",
+            "games": 5
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "MIN",
-              "games": 6
+              "team": "CAR",
+              "games": 7
             },
             {
               "person": "cklosowski",
-              "team": "STL",
-              "games": 6
+              "team": "NYI",
+              "games": 4
             },
             {
               "person": "jonathan",
-              "team": "STL",
-              "games": 5
+              "team": "CAR",
+              "games": 4
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "NYI",
+              "games": 6
             },
             {
               "person": "flynn",
-              "team": "MIN",
+              "team": "CAR",
               "games": 5
             },
             {
               "person": "zack",
-              "team": "STL",
-              "games": 6
+              "team": "CAR",
+              "games": 4
             },
             {
               "person": "john",
-              "team": "MIN",
-              "games": 6
+              "team": "CAR",
+              "games": 5
             }
           ]
         },
         {
           "teams": [
-            "CGY",
-            "DAL"
+            "DAL",
+            "VGK"
           ],
           "result": {
             "status": "final",
-            "winner": "CGY",
+            "winner": "DAL",
             "games": 7
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "CGY",
-              "games": 6
+              "team": "VGK",
+              "games": 4
             },
             {
               "person": "cklosowski",
-              "team": "CGY",
+              "team": "VGK",
+              "games": 6
+            },
+            {
+              "person": "jonathan",
+              "team": "DAL",
+              "games": 5
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "VGK",
+              "games": 7
+            },
+            {
+              "person": "flynn",
+              "team": "DAL",
+              "games": 7
+            },
+            {
+              "person": "zack",
+              "team": "VGK",
+              "games": 7
+            },
+            {
+              "person": "john",
+              "team": "VGK",
+              "games": 7
+            }
+          ]
+        },
+        {
+          "teams": [
+            "WPG",
+            "COL"
+          ],
+          "result": {
+            "status": "final",
+            "winner": "COL",
+            "games": 5
+          },
+          "picks": [
+            {
+              "person": "aaron",
+              "team": "COL",
+              "games": 4
+            },
+            {
+              "person": "cklosowski",
+              "team": "COL",
               "games": 4
             },
             {
               "person": "jonathan",
-              "team": "CGY",
-              "games": 6
+              "team": "WPG",
+              "games": 5
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "COL",
+              "games": 7
             },
             {
               "person": "flynn",
-              "team": "CGY",
+              "team": "WPG",
+              "games": 7
+            },
+            {
+              "person": "zack",
+              "team": "COL",
+              "games": 5
+            },
+            {
+              "person": "john",
+              "team": "COL",
+              "games": 7
+            }
+          ]
+        },
+        {
+          "teams": [
+            "VAN",
+            "NSH"
+          ],
+          "result": {
+            "status": "final",
+            "winner": "VAN",
+            "games": 6
+          },
+          "picks": [
+            {
+              "person": "aaron",
+              "team": "VAN",
+              "games": 6
+            },
+            {
+              "person": "cklosowski",
+              "team": "VAN",
+              "games": 5
+            },
+            {
+              "person": "jonathan",
+              "team": "VAN",
+              "games": 4
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "VAN",
+              "games": 5
+            },
+            {
+              "person": "flynn",
+              "team": "VAN",
               "games": 5
             },
             {
               "person": "zack",
-              "team": "CGY",
-              "games": 6
+              "team": "VAN",
+              "games": 5
             },
             {
               "person": "john",
-              "team": "CGY",
-              "games": 7
+              "team": "VAN",
+              "games": 6
             }
           ]
         },
@@ -318,23 +353,28 @@
           "result": {
             "status": "final",
             "winner": "EDM",
-            "games": 7
+            "games": 5
           },
           "picks": [
             {
               "person": "aaron",
               "team": "EDM",
-              "games": 4
+              "games": 5
             },
             {
               "person": "cklosowski",
               "team": "EDM",
-              "games": 5
+              "games": 4
             },
             {
               "person": "jonathan",
               "team": "EDM",
               "games": 4
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "EDM",
+              "games": 6
             },
             {
               "person": "flynn",
@@ -343,13 +383,13 @@
             },
             {
               "person": "zack",
-              "team": "LAK",
-              "games": 7
+              "team": "EDM",
+              "games": 6
             },
             {
               "person": "john",
               "team": "EDM",
-              "games": 5
+              "games": 6
             }
           ]
         }
@@ -362,33 +402,38 @@
         {
           "teams": [
             "FLA",
-            "TBL"
+            "BOS"
           ],
           "result": {
             "status": "final",
-            "winner": "TBL",
-            "games": 4
+            "winner": "FLA",
+            "games": 6
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "TBL",
-              "games": 6
+              "team": "BOS",
+              "games": 7
             },
             {
               "person": "cklosowski",
               "team": "FLA",
-              "games": 6
+              "games": 5
             },
             {
               "person": "jonathan",
+              "team": "FLA",
+              "games": 6
+            },
+            {
+              "person": "nerdybyproxy",
               "team": "FLA",
               "games": 7
             },
             {
               "person": "flynn",
-              "team": "TBL",
-              "games": 7
+              "team": "FLA",
+              "games": 5
             },
             {
               "person": "zack",
@@ -404,18 +449,18 @@
         },
         {
           "teams": [
-            "CAR",
-            "NYR"
+            "NYR",
+            "CAR"
           ],
           "result": {
             "status": "final",
             "winner": "NYR",
-            "games": 7
+            "games": 6
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "CAR",
+              "team": "NYR",
               "games": 6
             },
             {
@@ -425,64 +470,59 @@
             },
             {
               "person": "jonathan",
-              "team": "CAR",
-              "games": 5
+              "team": "NYR",
+              "games": 6
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "NYR",
+              "games": 6
             },
             {
               "person": "flynn",
               "team": "CAR",
-              "games": 6
-            },
-            {
-              "person": "zack",
-              "team": "CAR",
-              "games": 6
+              "games": 7
             },
             {
               "person": "john",
-              "team": "CAR",
-              "games": 7
+              "team": "NYR",
+              "games": 5
             }
           ]
         },
         {
           "teams": [
-            "COL",
-            "STL"
+            "DAL",
+            "COL"
           ],
           "result": {
             "status": "final",
-            "winner": "COL",
+            "winner": "DAL",
             "games": 6
           },
           "picks": [
             {
               "person": "aaron",
               "team": "COL",
-              "games": 6
+              "games": 7
             },
             {
               "person": "cklosowski",
               "team": "COL",
-              "games": 5
-            },
-            {
-              "person": "jonathan",
-              "team": "COL",
               "games": 6
             },
             {
-              "person": "flynn",
+              "person": "jonathan",
+              "team": "DAL",
+              "games": 7
+            },
+            {
+              "person": "nerdybyproxy",
               "team": "COL",
               "games": 6
             },
             {
               "person": "zack",
-              "team": "COL",
-              "games": 6
-            },
-            {
-              "person": "john",
               "team": "COL",
               "games": 6
             }
@@ -490,43 +530,48 @@
         },
         {
           "teams": [
-            "CGY",
+            "VAN",
             "EDM"
           ],
           "result": {
             "status": "final",
             "winner": "EDM",
-            "games": 5
+            "games": 7
           },
           "picks": [
             {
               "person": "aaron",
-              "team": "CGY",
-              "games": 7
+              "team": "EDM",
+              "games": 6
             },
             {
               "person": "cklosowski",
               "team": "EDM",
-              "games": 7
+              "games": 5
             },
             {
               "person": "jonathan",
               "team": "EDM",
-              "games": 7
+              "games": 5
+            },
+            {
+              "person": "nerdybyproxy",
+              "team": "EDM",
+              "games": 5
             },
             {
               "person": "flynn",
-              "team": "CGY",
+              "team": "VAN",
               "games": 6
             },
             {
               "person": "zack",
               "team": "EDM",
-              "games": 7
+              "games": 6
             },
             {
               "person": "john",
-              "team": "CGY",
+              "team": "EDM",
               "games": 6
             }
           ]
@@ -539,87 +584,67 @@
       "series": [
         {
           "teams": [
-            "NYR",
-            "TBL"
+            "FLA",
+            "NYR"
           ],
           "result": {
             "status": "final",
-            "winner": "TBL",
+            "winner": "FLA",
             "games": 6
           },
           "picks": [
             {
-              "person": "aaron",
-              "team": "TBL",
-              "games": 6
-            },
-            {
-              "person": "cklosowski",
-              "team": "TBL",
-              "games": 5
-            },
-            {
-              "person": "jonathan",
-              "team": "TBL",
+              "person": "nerdybyproxy",
+              "team": "FLA",
               "games": 6
             },
             {
               "person": "flynn",
-              "team": "TBL",
-              "games": 5
+              "team": "FLA",
+              "games": 6
             },
             {
               "person": "zack",
-              "team": "TBL",
-              "games": 6
+              "team": "FLA",
+              "games": 7
             },
             {
               "person": "john",
-              "team": "TBL",
-              "games": 6
+              "team": "FLA",
+              "games": 7
             }
           ]
         },
         {
           "teams": [
-            "COL",
+            "DAL",
             "EDM"
           ],
           "result": {
             "status": "final",
-            "winner": "COL",
-            "games": 4
+            "winner": "EDM",
+            "games": 6
           },
           "picks": [
             {
-              "person": "aaron",
-              "team": "EDM",
-              "games": 7
-            },
-            {
-              "person": "cklosowski",
+              "person": "nerdybyproxy",
               "team": "EDM",
               "games": 6
             },
             {
-              "person": "jonathan",
-              "team": "EDM",
-              "games": 7
-            },
-            {
               "person": "flynn",
-              "team": "COL",
-              "games": 7
+              "team": "DAL",
+              "games": 6
             },
             {
               "person": "zack",
-              "team": "COL",
-              "games": 7
+              "team": "DAL",
+              "games": 4
             },
             {
               "person": "john",
               "team": "EDM",
-              "games": 7
+              "games": 6
             }
           ]
         }
@@ -631,44 +656,34 @@
       "series": [
         {
           "teams": [
-            "COL",
-            "TBL"
+            "EDM",
+            "FLA"
           ],
           "result": {
             "status": "final",
-            "winner": "COL",
-            "games": 6
+            "winner": "FLA",
+            "games": 7
           },
           "picks": [
             {
-              "person": "aaron",
-              "team": "COL",
-              "games": 6
-            },
-            {
-              "person": "cklosowski",
-              "team": "COL",
+              "person": "nerdybyproxy",
+              "team": "FLA",
               "games": 5
             },
             {
-              "person": "jonathan",
-              "team": "TBL",
-              "games": 7
-            },
-            {
               "person": "flynn",
-              "team": "COL",
+              "team": "FLA",
               "games": 6
             },
             {
               "person": "zack",
-              "team": "COL",
-              "games": 6
+              "team": "FLA",
+              "games": 5
             },
             {
               "person": "john",
-              "team": "COL",
-              "games": 7
+              "team": "EDM",
+              "games": 6
             }
           ]
         }

--- a/data/index.json
+++ b/data/index.json
@@ -12,9 +12,19 @@
       "champion": "FLA"
     },
     {
+      "year": 2024,
+      "status": "complete",
+      "champion": "FLA"
+    },
+    {
+      "year": 2023,
+      "status": "complete",
+      "champion": "VGK"
+    },
+    {
       "year": 2022,
-      "status": "in-progress",
-      "champion": null
+      "status": "complete",
+      "champion": "COL"
     },
     {
       "year": 2021,

--- a/data/people.json
+++ b/data/people.json
@@ -13,6 +13,9 @@
     "emailHash": "9c5813f24d1c3617dc92c4020fd4c55eba140ccc61cb68eed77b711819d048ee",
     "aliases": [
       "@vegasgeek",
+      "@VegasGeek",
+      "@VegasGeeek",
+      "VegasGeek",
       "John Hawkins",
       "John"
     ]
@@ -46,6 +49,12 @@
       "@aaronjorbin",
       "Aaron Jorbin",
       "Aaron"
+    ]
+  },
+  "nerdybyproxy": {
+    "name": "@NerdyByProxy",
+    "aliases": [
+      "@NerdyByProxy"
     ]
   },
   "nacin": {

--- a/scripts/verify-data.mjs
+++ b/scripts/verify-data.mjs
@@ -12,6 +12,9 @@ const readJSON = async (p) => JSON.parse(await readFile(path.join(dataDir, p), '
 
 // Documented final standings (person id -> total) we are confident about.
 const DOCUMENTED = {
+  2022: { zack: 38, flynn: 36, aaron: 30, john: 29, cklosowski: 28, jonathan: 25 },
+  2023: { nerdybyproxy: 36, john: 34, jonathan: 29, cklosowski: 25, zack: 25, flynn: 17, aaron: 6 },
+  2024: { john: 38, nerdybyproxy: 37, flynn: 32, zack: 31, jonathan: 24, aaron: 20, cklosowski: 9 },
   2025: { aaron: 37, jonathan: 32, zack: 31, john: 27, flynn: 23 },
   2026: { john: 39, zack: 27, flynn: 26, jonathan: 19, aaron: 12 },
 };


### PR DESCRIPTION
Fills in the playoff seasons missing from the repo using the two CSVs John Hawkins posted in the "Playoffs!!!!" email thread (`hockeypool_picks_2022.csv` and `hockeypool_picks_all_years.csv`; the former is a subset of the latter). The export covers 2022, 2023, and 2024 and records both teams, every pick, the predicted game count, and the actual result per series.

## What changed
- **2023 and 2024**: added (`data/2023.json`, `data/2024.json`). Both were entirely missing.
- **2022**: replaced the partial reconstruction (rounds 1-2 only, champion unknown) with John's authoritative full season. Now `complete`, champion `COL`. The earlier reconstruction's rounds 1-2 results matched the CSV exactly; this adds the Conference Finals and Cup Final. `matchupsReconstructed` flips to `false`.
- `data/index.json`: 2024 and 2023 added; 2022 updated to `complete` / `COL`.
- `data/people.json`: added `@NerdyByProxy` (handle-only, like the other early handles); added John's CSV handle variants (`@VegasGeek`, `@VegasGeeek`, `VegasGeek`) as aliases.
- `scripts/verify-data.mjs`: documented per-player totals for 2022-2024 added as guards.
- `README.md`: provenance updated (2022-2024 now from the hockeypool export; 2018-2021 remain reconstructed).

## Data handling notes
- Team codes canonicalized to NHL abbreviations: `CAL`->`CGY`, `NAS`->`NSH`, `WAS`->`WSH`, `WIN`->`WPG`.
- Player handles mapped to existing ids (`@AaronJorbin`->aaron, `@desrosj`->jonathan, `@thoronas`->flynn, `@tollmanz`->zack, the VegasGeek variants->john, `@cklosowski` unchanged).
- Skipped picks (empty `picked_winner`) become no pick for that series, matching the data model. Aaron skipped the 2023/2024 deep rounds; a few others skipped single series.
- `@ThomasKnoll` registered for 2024 but submitted zero picks, so he holds no series and does not appear (the data model has no roster-without-picks concept). Flagged here in case you want to record him some other way.

## Verification
`npm run verify` passes: schema checks hold and scores recompute from `rules.json` to match the CSV's own points column for all three years. `npm run build` renders the new year pages.

Champions: 2022 COL (zack wins the pool, 38), 2023 VGK (nerdybyproxy 36), 2024 FLA (john 38).

Do not merge yet, pending review.